### PR TITLE
Fix call_service_tool validation error for empty list responses

### DIFF
--- a/app/hass.py
+++ b/app/hass.py
@@ -508,17 +508,24 @@ async def call_service(domain: str, service: str, data: Optional[Dict[str, Any]]
     await _rate_limiter.acquire()
     client = await get_client()
     response = await client.post(
-        f"{HA_URL}/api/services/{domain}/{service}", 
+        f"{HA_URL}/api/services/{domain}/{service}",
         headers=get_ha_headers(),
         json=data
     )
     response.raise_for_status()
-    
+
     # Invalidate cache after service calls as they might change entity states
     global _entities_timestamp
     _entities_timestamp = 0
-    
-    return response.json()
+
+    result = response.json()
+
+    # Handle empty list responses from Home Assistant
+    # Some service calls return [] for successful operations with no data
+    if result == []:
+        result = {}
+
+    return result
 
 @handle_api_errors
 async def summarize_domain(domain: str, example_limit: int = 3) -> Dict[str, Any]:

--- a/tests/test_hass.py
+++ b/tests/test_hass.py
@@ -82,33 +82,63 @@ class TestHassAPI:
         domain = "light"
         service = "turn_on"
         data = {"entity_id": "light.living_room", "brightness": 255}
-        
+
         # Create mock response
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = {"result": "ok"}
-        
+
         # Create properly awaitable mock
         mock_client = MagicMock()
         mock_client.post = AsyncMock(return_value=mock_response)
-        
+
         # Patch the client
         with patch('app.hass.get_client', return_value=mock_client):
             with patch('app.hass.HA_URL', mock_config["hass_url"]):
                 with patch('app.hass.HA_TOKEN', mock_config["hass_token"]):
                         # Test function
                         result = await call_service(domain, service, data)
-                        
+
                         # Assertions
                         assert isinstance(result, dict)
                         assert result["result"] == "ok"
-                        
+
                         # Verify API was called correctly
                         mock_client.post.assert_called_once()
                         called_url = mock_client.post.call_args[0][0]
                         called_data = mock_client.post.call_args[1].get('json')
                         assert called_url == f"{mock_config['hass_url']}/api/services/{domain}/{service}"
                         assert called_data == data
+
+    @pytest.mark.asyncio
+    async def test_call_service_empty_list_response(self, mock_config):
+        """Test calling a service that returns an empty list (should be converted to dict)."""
+        domain = "cast"
+        service = "show_lovelace_view"
+        data = {"entity_id": "media_player.cast_device", "view_path": "home"}
+
+        # Create mock response that returns empty list (as HA does for some service calls)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = []
+
+        # Create properly awaitable mock
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        # Patch the client
+        with patch('app.hass.get_client', return_value=mock_client):
+            with patch('app.hass.HA_URL', mock_config["hass_url"]):
+                with patch('app.hass.HA_TOKEN', mock_config["hass_token"]):
+                        # Test function
+                        result = await call_service(domain, service, data)
+
+                        # Assertions - empty list should be converted to empty dict
+                        assert isinstance(result, dict)
+                        assert result == {}
+
+                        # Verify API was called correctly
+                        mock_client.post.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_automations(self, mock_config):


### PR DESCRIPTION
Fixes #4

## Summary

This PR fixes the Pydantic validation error that occurred when Home Assistant service calls returned empty lists.

## Changes

- Modified `call_service` in `app/hass.py` to convert empty list `[]` responses to empty dict `{}`
- Added test case `test_call_service_empty_list_response` to verify the fix

## Root Cause

Home Assistant returns `[]` for successful service calls with no response data (e.g., `cast.show_lovelace_view`, `automation.trigger`, `media_player.turn_off`). The Pydantic model expected a `dict`, causing validation errors.

## Testing

Added unit test to verify empty list responses are correctly converted to empty dictionaries.

---

Generated with [Claude Code](https://claude.ai/code)